### PR TITLE
add knn estimators and fix mi implementation

### DIFF
--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -43,7 +43,8 @@ def ent(n_bins, rng, method, *args):
                         for arg in args]))
 
     if method == 'knn':
-        return knn_ent(*args, k=n_bins or 3)
+        return knn_ent(*args, k=n_bins or 3,
+                       boxsize=diff(rng).max() if rng[0] else None)
 
     if rng is None or None in rng:
         rng = len(args)*[None]
@@ -65,7 +66,7 @@ def ent(n_bins, rng, method, *args):
     return naive(counts)
 
 
-def ce(n_bins, x, y, rng=None, method='grassberger'):
+def ce(n_bins, x, y, rng=None, method='knn'):
     """Condtional entropy calculation
 
     Parameters
@@ -88,7 +89,7 @@ def ce(n_bins, x, y, rng=None, method='grassberger'):
             ent(n_bins, [rng], method, y))
 
 
-def knn_ent(*args, k=3):
+def knn_ent(*args, k=3, boxsize=None):
     """ The classic K-L k-nearest neighbor continuous entropy estimator
         x should be a list of vectors, e.g. x = [[1.3], [3.7], [5.1], [2.4]]
         if x is a one-dimensional scalar and we have four samples
@@ -98,7 +99,7 @@ def knn_ent(*args, k=3):
     n_dims = data.shape[1]
 
     data += EPS * random.rand(n_samples, n_dims)
-    tree = cKDTree(data)
+    tree = cKDTree(data, boxsize=boxsize)
     nn = [tree.query(point, k + 1, p=float('inf'))[0][k] for point in data]
     const = psi(n_samples) - psi(k) + n_dims * log(2)
 

--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -108,7 +108,7 @@ def knn_ent(*args, k=None, boxsize=None):
     """
     data = vstack((args)).T
     n_samples = data.shape[0]
-    k = k if k else int(n_samples * 0.1)
+    k = k if k else int(n_samples * 0.01)
     n_dims = data.shape[1]
 
     data += EPS * random.rand(n_samples, n_dims)

--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -41,6 +41,9 @@ def ent(n_bins, rng, method, *args):
                         else [arg]
                         for arg in args]))
 
+    if method == 'knn':
+        return knn_ent(*args, k=n_bins or 3)
+
     if rng is None or None in rng:
         rng = len(args)*[None]
 
@@ -50,8 +53,6 @@ def ent(n_bins, rng, method, *args):
 
     if method == 'kde':
         return kde_ent(rng, *args, grid_size=n_bins or 20)
-    if method == 'knn':
-        return knn_ent(*args, k=n_bins or 3)
 
     counts = symbolic(n_bins, rng, *args)
 

--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -4,7 +4,7 @@ from itertools import chain
 
 from numpy import ndarray
 from numpy import sum as npsum
-from numpy import (arange, bincount, diff, linspace, log, log2,
+from numpy import (arange, bincount, diff, finfo, linspace, log, log2,
                    meshgrid, nan_to_num, nansum, product,
                    random, ravel, split, vstack, exp)
 
@@ -16,6 +16,7 @@ from scipy.special import psi
 from sklearn.neighbors import KernelDensity
 
 __all__ = ['ent', 'ce']
+EPS = finfo(float).eps
 
 
 def ent(n_bins, rng, method, *args):
@@ -96,11 +97,11 @@ def knn_ent(*args, k=3):
     n_samples = data.shape[0]
     n_dims = data.shape[1]
 
-    intens = 1e-6  # small noise to break degeneracy, see doc.
-    data = [pt + intens * random.rand(n_dims) for pt in data]
+    data += EPS * random.rand(n_samples, n_dims)
     tree = cKDTree(data)
     nn = [tree.query(point, k + 1, p=float('inf'))[0][k] for point in data]
     const = psi(n_samples) - psi(k) + n_dims * log(2)
+
     return (const + n_dims * log(nn).mean())/log(2)
 
 

--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -108,7 +108,7 @@ def knn_ent(*args, k=None, boxsize=None):
     """
     data = vstack((args)).T
     n_samples = data.shape[0]
-    k = k if k else int(n_samples * 0.01)
+    k = k if k else max(3, int(data.shape[0] * 0.01))
     n_dims = data.shape[1]
 
     data += EPS * random.rand(n_samples, n_dims)

--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -4,8 +4,8 @@ from itertools import chain
 
 from numpy import ndarray
 from numpy import sum as npsum
-from numpy import (arange, bincount, diff, finfo, linspace, log, log2,
-                   meshgrid, nan_to_num, nansum, product,
+from numpy import (arange, bincount, diff, finfo, float32, linspace,
+                   log, log2, meshgrid, nan_to_num, nansum, product,
                    random, ravel, split, vstack, exp)
 
 from scipy.spatial import cKDTree
@@ -16,7 +16,7 @@ from scipy.special import psi
 from sklearn.neighbors import KernelDensity
 
 __all__ = ['ent', 'ce']
-EPS = finfo(float).eps
+EPS = finfo(float32).eps
 
 
 def ent(n_bins, rng, method, *args):

--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -90,9 +90,20 @@ def ce(n_bins, x, y, rng=None, method='knn'):
 
 
 def knn_ent(*args, k=3, boxsize=None):
-    """ The classic K-L k-nearest neighbor continuous entropy estimator
-        x should be a list of vectors, e.g. x = [[1.3], [3.7], [5.1], [2.4]]
-        if x is a one-dimensional scalar and we have four samples
+    """Entropy calculation
+
+    Parameters
+    ----------
+    args : numpy.ndarray, shape = (n_samples, ) or (n_features, n_samples)
+        Data of which to calculate entropy. Each array must have the same
+        number of samples.
+    k : int
+        Number of bins.
+    boxsize : float (or None)
+        Wrap space between [0., boxsize)
+    Returns
+    -------
+    entropy : float
     """
     data = vstack((args)).T
     n_samples = data.shape[0]

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -1,13 +1,13 @@
 from .entropy import ent, ce
 from ..utils import avgdigamma
 
-from numpy import finfo, log, nan_to_num, random, sqrt, vstack
+from numpy import finfo, float32, log, nan_to_num, random, sqrt, vstack
 
 from scipy.spatial import cKDTree
 from scipy.special import psi
 
 __all__ = ['mi', 'nmi', 'cmi', 'ncmi']
-EPS = finfo(float).eps
+EPS = finfo(float32).eps
 
 
 def mi(n_bins, x, y, rng=None, method='grassberger'):

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -62,7 +62,7 @@ def knn_mi(x, y, k=None,  boxsize=None):
     y += EPS * random.rand(*y.shape)
     points = hstack((x, y))
 
-    k = k if k else int(points.shape[0] * 0.01)
+    k = k if k else max(3, int(points.shape[0] * 0.01))
 
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points, boxsize=boxsize)
@@ -152,7 +152,7 @@ def knn_cmi(x, y, z, k=None, boxsize=None):
     z += EPS * random.rand(*z.shape)
     points = hstack((x, y, z))
 
-    k = k if k else int(points.shape[0] * 0.01)
+    k = k if k else max(3, int(points.shape[0] * 0.01))
 
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points, boxsize=boxsize)

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -2,7 +2,7 @@ from .entropy import ent, ce
 from ..utils import avgdigamma
 
 from numpy import (atleast_2d, diff, finfo, float32, log, nan_to_num, random,
-                   sqrt, hstack)
+                   sqrt, hstack, vstack)
 
 from scipy.spatial import cKDTree
 from scipy.special import psi
@@ -62,7 +62,7 @@ def knn_mi(x, y, k=None,  boxsize=None):
     y += EPS * random.rand(*y.shape)
     points = hstack((x, y))
 
-    k = k if k else int(points.shape[0] * 0.1)
+    k = k if k else int(points.shape[0] * 0.01)
 
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points, boxsize=boxsize)
@@ -152,13 +152,13 @@ def knn_cmi(x, y, z, k=None, boxsize=None):
     z += EPS * random.rand(*z.shape)
     points = hstack((x, y, z))
 
-    k = k if k else int(points.shape[0] * 0.1)
+    k = k if k else int(points.shape[0] * 0.01)
 
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points, boxsize=boxsize)
     dvec = [tree.query(point, k + 1, p=float('inf'))[0][k] for point in points]
-    a, b, c, d = (avgdigamma(hstack((x, z)), dvec),
-                  avgdigamma(hstack((y, z)), dvec),
+    a, b, c, d = (avgdigamma(vstack((x, z)).T, dvec),
+                  avgdigamma(vstack((y, z)).T, dvec),
                   avgdigamma(atleast_2d(z).reshape(points.shape[0], -1), dvec),
                   psi(k))
     return (-a - b + c + d) / log(2)

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -2,7 +2,7 @@ from .entropy import ent, ce
 from ..utils import avgdigamma
 
 from numpy import (atleast_2d, diff, finfo, float32, log, nan_to_num, random,
-                   sqrt, vstack)
+                   sqrt, hstack)
 
 from scipy.spatial import cKDTree
 from scipy.special import psi
@@ -60,7 +60,7 @@ def knn_mi(x, y, k=None,  boxsize=None):
 
     x += EPS * random.rand(*x.shape)
     y += EPS * random.rand(*y.shape)
-    points = vstack((x, y)).T
+    points = hstack((x, y))
 
     k = k if k else int(points.shape[0] * 0.1)
 
@@ -150,15 +150,15 @@ def knn_cmi(x, y, z, k=None, boxsize=None):
     x += EPS * random.rand(*x.shape)
     y += EPS * random.rand(*y.shape)
     z += EPS * random.rand(*z.shape)
-    points = vstack((x, y, z)).T
+    points = hstack((x, y, z))
 
     k = k if k else int(points.shape[0] * 0.1)
 
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points, boxsize=boxsize)
     dvec = [tree.query(point, k + 1, p=float('inf'))[0][k] for point in points]
-    a, b, c, d = (avgdigamma(vstack((x, z)).T, dvec),
-                  avgdigamma(vstack((y, z)).T, dvec),
+    a, b, c, d = (avgdigamma(hstack((x, z)), dvec),
+                  avgdigamma(hstack((y, z)), dvec),
                   avgdigamma(atleast_2d(z).reshape(points.shape[0], -1), dvec),
                   psi(k))
     return (-a - b + c + d) / log(2)

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -2,7 +2,7 @@ from .entropy import ent, ce
 from ..utils import avgdigamma
 
 from numpy import (atleast_2d, diff, finfo, float32, log, nan_to_num, random,
-                   sqrt, hstack, vstack)
+                   sqrt, hstack)
 
 from scipy.spatial import cKDTree
 from scipy.special import psi
@@ -157,8 +157,8 @@ def knn_cmi(x, y, z, k=None, boxsize=None):
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points, boxsize=boxsize)
     dvec = [tree.query(point, k + 1, p=float('inf'))[0][k] for point in points]
-    a, b, c, d = (avgdigamma(vstack((x, z)).T, dvec),
-                  avgdigamma(vstack((y, z)).T, dvec),
+    a, b, c, d = (avgdigamma(hstack((x, z)), dvec),
+                  avgdigamma(hstack((y, z)), dvec),
                   avgdigamma(atleast_2d(z).reshape(points.shape[0], -1), dvec),
                   psi(k))
     return (-a - b + c + d) / log(2)

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -39,9 +39,21 @@ def mi(n_bins, x, y, rng=None, method='knn'):
 
 
 def knn_mi(x, y, k=3,  boxsize=None):
-    """ Mutual information of x and y
-        x, y should be a list of vectors, e.g. x = [[1.3], [3.7], [5.1], [2.4]]
-        if x is a one-dimensional scalar and we have four samples
+    """Entropy calculation
+
+    Parameters
+    ----------
+    x : array_like, shape = (n_samples, )
+        Independent variable
+    y : array_like, shape = (n_samples, )
+        Independent variable
+    k : int
+        Number of bins.
+    boxsize : float (or None)
+        Wrap space between [0., boxsize)
+    Returns
+    -------
+    mi : float
     """
     # small noise to break degeneracy, see doc.
 
@@ -112,9 +124,23 @@ def cmi(n_bins, x, y, z, rng=None, method='knn'):
 
 
 def knn_cmi(x, y, z, k=3, boxsize=None):
-    """ Mutual information of x and y, conditioned on z
-        x, y, z should be a list of vectors, e.g. x = [[1.3], [3.7], [5.1], [2.4]]
-        if x is a one-dimensional scalar and we have four samples
+    """Entropy calculation
+
+    Parameters
+    ----------
+    x : array_like, shape = (n_samples, )
+        Conditioned variable
+    y : array_like, shape = (n_samples, )
+        Conditioned variable
+    z : array_like, shape = (n_samples, )
+        Conditional variable
+    k : int
+        Number of bins.
+    boxsize : float (or None)
+        Wrap space between [0., boxsize)
+    Returns
+    -------
+    cmi : float
     """
     # small noise to break degeneracy, see doc.
     x += EPS * random.rand(x.shape[0], x.shape[1])
@@ -149,7 +175,7 @@ def ncmi(n_bins, x, y, z, rng=None, method='knn'):
         Method used to calculate entropy.
     Returns
     -------
-    entropy : float
+    ncmi : float
     """
 
     return (cmi(n_bins, x, y, z, rng=rng, method=method) /

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -50,8 +50,8 @@ def knn_mi(x, y, k=3):
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points)
     dvec = [tree.query(point, k + 1, p=float('inf'))[0][k] for point in points]
-    a, b, c, d = (avgdigamma(x, dvec), avgdigamma(y, dvec),
-                  psi(k), psi(x.shape[0]))
+    a, b, c, d = (avgdigamma(x.T, dvec), avgdigamma(y.T, dvec),
+                  psi(k), psi(points.shape[0]))
     return (-a - b + c + d) / log(2)
 
 
@@ -118,13 +118,13 @@ def knn_cmi(x, y, z, k=3):
     x += EPS * random.rand(x.shape[0], x.shape[1])
     y += EPS * random.rand(y.shape[0], y.shape[1])
     z += EPS * random.rand(z.shape[0], z.shape[1])
-    points = vstack((x, y)).T
+    points = vstack((x, y, z)).T
     # Find nearest neighbors in joint space, p=inf means max-norm
     tree = cKDTree(points)
     dvec = [tree.query(point, k + 1, p=float('inf'))[0][k] for point in points]
     a, b, c, d = (avgdigamma(vstack((x, z)).T, dvec),
                   avgdigamma(vstack((y, z)).T, dvec),
-                  avgdigamma(z, dvec), psi(k))
+                  avgdigamma(z.T, dvec), psi(k))
     return (-a - b + c + d) / log(2)
 
 

--- a/mdentropy/metrics/base.py
+++ b/mdentropy/metrics/base.py
@@ -55,7 +55,7 @@ class BaseMetric(object):
                 self._shuffle()
                 correction += self._floored_exec()
 
-        return floor_threshold(result - (correction / shuffle))
+        return floor_threshold(result - np.nan_to_num(correction / shuffle))
 
     def transform(self, trajs, shuffle=0, verbose=False):
         """Invokes partial_transform over a list of mdtraj.Trajectory objects
@@ -103,12 +103,13 @@ class DihedralBaseMetric(BaseMetric):
             summary = featurizer.describe_features(traj)
             idx = [[traj.topology.atom(ati).residue.index
                     for ati in item['atominds']][1] for item in summary]
-            data.append(pd.DataFrame(180. * angles / np.pi,
-                                     columns=[idx, len(idx) * [tp]]))
+            data.append(pd.DataFrame((angles + np.pi) % (2. * np.pi),
+                        columns=[idx, len(idx) * [tp]]))
         return pd.concat(data, axis=1)
 
-    def __init__(self, types=None, **kwargs):
+    def __init__(self, types=None, rng=None, **kwargs):
         self.types = types or ['phi', 'psi']
+        self.rng = rng or [0., 2 * np.pi]
 
         super(DihedralBaseMetric, self).__init__(**kwargs)
 

--- a/mdentropy/metrics/base.py
+++ b/mdentropy/metrics/base.py
@@ -77,7 +77,7 @@ class BaseMetric(object):
             yield self.partial_transform(traj, shuffle=shuffle,
                                          verbose=verbose)
 
-    def __init__(self, n_bins=24, rng=None, method='grassberger',
+    def __init__(self, n_bins=3, rng=None, method='knn',
                  threads=None):
         self.data = None
         self.shuffled_data = None

--- a/mdentropy/metrics/mutinf.py
+++ b/mdentropy/metrics/mutinf.py
@@ -20,8 +20,8 @@ class MutualInformationBase(BaseMetric):
         i, j = p
 
         return self._est(self.n_bins,
-                         self.data[i].values.T,
-                         self.shuffled_data[j].values.T,
+                         self.data[i].values,
+                         self.shuffled_data[j].values,
                          rng=self.rng,
                          method=self.method)
 

--- a/mdentropy/metrics/mutinf.py
+++ b/mdentropy/metrics/mutinf.py
@@ -27,18 +27,14 @@ class MutualInformationBase(BaseMetric):
 
     def _exec(self):
         M = np.zeros((self.labels.size, self.labels.size))
-        triu = np.zeros((int((self.labels.size ** 2 + self.labels.size) / 2),))
 
         with closing(Pool(processes=self.n_threads)) as pool:
             values = pool.map(self._partial_mutinf,
                               combinations(self.labels, 2))
             pool.terminate()
 
-        for i, value in enumerate(values):
-            triu[i] = value
-
         idx = np.triu_indices_from(M)
-        M[idx] = triu
+        M[idx] = values
 
         return M + M.T - np.diag(M.diagonal())
 

--- a/mdentropy/metrics/tent.py
+++ b/mdentropy/metrics/tent.py
@@ -21,9 +21,9 @@ class TransferEntropyBase(BaseMetric):
         i, j = p
 
         return self._est(self.n_bins,
-                         self.data[j].values.T,
-                         self.shuffled_data[i].values.T,
-                         self.shuffled_data[j].values.T,
+                         self.data[j].values,
+                         self.shuffled_data[i].values,
+                         self.shuffled_data[j].values,
                          rng=self.rng,
                          method=self.method)
 

--- a/mdentropy/tests/test_entropy.py
+++ b/mdentropy/tests/test_entropy.py
@@ -16,7 +16,8 @@ def test_kde():
 
 
 def test_knn():
-    eq(ent(3, RNG, 'knn', a, b), TRUE_ENTROPY, rtol=.4)
+    eq(ent(3, [None], 'knn', a.reshape(-1, 1), b.reshape(-1, 1)), TRUE_ENTROPY,
+       rtol=.4)
 
 
 def test_chaowangjost():

--- a/mdentropy/tests/test_entropy.py
+++ b/mdentropy/tests/test_entropy.py
@@ -15,6 +15,10 @@ def test_kde():
     eq(ent(8, RNG, 'kde', a, b), TRUE_ENTROPY, rtol=.4)
 
 
+def test_knn():
+    eq(ent(3, RNG, 'knn', a, b), TRUE_ENTROPY, rtol=.4)
+
+
 def test_chaowangjost():
     eq(ent(8, RNG, 'chaowangjost', a, b), TRUE_ENTROPY, rtol=.2)
 

--- a/mdentropy/tests/test_mi.py
+++ b/mdentropy/tests/test_mi.py
@@ -17,8 +17,8 @@ def test_mi():
     a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
     b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
 
-    MI1 = mi(24, a, b, rng=[-180., 180.])
-    MI2 = mi(24, b, a, rng=[-180., 180.])
+    MI1 = mi(10, a, b)
+    MI2 = mi(10, b, a)
 
     eq(MI1, MI2, 6)
 
@@ -27,8 +27,8 @@ def test_nmi():
     a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
     b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
 
-    MI1 = nmi(24, a, b, rng=[-180., 180.])
-    MI2 = nmi(24, b, a, rng=[-180., 180.])
+    MI1 = nmi(24, a, b)
+    MI2 = nmi(24, b, a)
 
     eq(MI1, MI2, 6)
 

--- a/mdentropy/tests/test_mi.py
+++ b/mdentropy/tests/test_mi.py
@@ -14,8 +14,8 @@ from msmbuilder.example_datasets import FsPeptide
 
 
 def test_mi():
-    a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
-    b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
+    a = np.random.uniform(low=0., high=360., size=1000).reshape(-1, 1)
+    b = np.random.uniform(low=0., high=360., size=1000).reshape(-1, 1)
 
     MI1 = mi(10, a, b)
     MI2 = mi(10, b, a)
@@ -24,8 +24,8 @@ def test_mi():
 
 
 def test_nmi():
-    a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
-    b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
+    a = np.random.uniform(low=0., high=360., size=1000).reshape(-1, 1)
+    b = np.random.uniform(low=0., high=360., size=1000).reshape(-1, 1)
 
     MI1 = nmi(24, a, b)
     MI2 = nmi(24, b, a)

--- a/mdentropy/tests/test_mi.py
+++ b/mdentropy/tests/test_mi.py
@@ -14,8 +14,8 @@ from msmbuilder.example_datasets import FsPeptide
 
 
 def test_mi():
-    a = np.random.uniform(low=-180., high=180, size=1000)
-    b = np.random.uniform(low=-180., high=180, size=1000)
+    a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
+    b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
 
     MI1 = mi(24, a, b, rng=[-180., 180.])
     MI2 = mi(24, b, a, rng=[-180., 180.])
@@ -24,8 +24,8 @@ def test_mi():
 
 
 def test_nmi():
-    a = np.random.uniform(low=-180., high=180, size=1000)
-    b = np.random.uniform(low=-180., high=180, size=1000)
+    a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
+    b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
 
     MI1 = nmi(24, a, b, rng=[-180., 180.])
     MI2 = nmi(24, b, a, rng=[-180., 180.])

--- a/mdentropy/tests/test_tent.py
+++ b/mdentropy/tests/test_tent.py
@@ -14,9 +14,9 @@ from msmbuilder.example_datasets import FsPeptide
 
 
 def test_ncmi():
-    a = np.random.uniform(low=-180., high=180, size=1000)
-    b = np.random.uniform(low=-180., high=180, size=1000)
-    c = np.random.uniform(low=-180., high=180, size=1000)
+    a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
+    b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
+    c = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
 
     NCMI_REF = (cmi(30, a, b, c, rng=[-180., 180.]) /
                 ce(30, a, c, rng=[-180., 180.]))

--- a/mdentropy/tests/test_tent.py
+++ b/mdentropy/tests/test_tent.py
@@ -14,9 +14,9 @@ from msmbuilder.example_datasets import FsPeptide
 
 
 def test_ncmi():
-    a = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
-    b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
-    c = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
+    a = np.random.uniform(low=0, high=360, size=1000).reshape(-1, 1)
+    b = np.random.uniform(low=0, high=360, size=1000).reshape(-1, 1)
+    c = np.random.uniform(low=0, high=360, size=1000).reshape(-1, 1)
 
     NCMI_REF = (cmi(10, a, b, c) /
                 ce(10, a, c))

--- a/mdentropy/tests/test_tent.py
+++ b/mdentropy/tests/test_tent.py
@@ -18,9 +18,9 @@ def test_ncmi():
     b = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
     c = np.random.uniform(low=-180., high=180, size=1000).reshape(-1, 1)
 
-    NCMI_REF = (cmi(30, a, b, c, rng=[-180., 180.]) /
-                ce(30, a, c, rng=[-180., 180.]))
-    NCMI = ncmi(30, a, b, c, rng=[-180., 180.])
+    NCMI_REF = (cmi(10, a, b, c) /
+                ce(10, a, c))
+    NCMI = ncmi(10, a, b, c)
 
     eq(NCMI, NCMI_REF, 6)
 

--- a/mdentropy/utils.py
+++ b/mdentropy/utils.py
@@ -86,15 +86,27 @@ def floor_threshold(arr, threshold=0.):
 
 
 def avgdigamma(points, dvec):
-    # This part finds number of neighbors in some radius in the marginal space
-    # returns expectation value of <psi(nx)>
+    """Convenience function for finding expectation value of <psi(nx)> given
+    some number of neighbors in some radius in a marginal space.
+
+    Parameters
+    ----------
+    points : numpy.ndarray
+    dvec : array_like (n_points,)
+    Returns
+    -------
+    avgdigamma : float
+        expectation value of <psi(nx)>
+    """
     n_samples = points.shape[0]
     tree = cKDTree(points)
+
     avg = 0.
     for i in range(n_samples):
         dist = dvec[i]
-        # subtlety, we don't include the boundary point,
-        # but we are implicitly adding 1 to kraskov def bc center point is included
+        # we don't include the boundary point,
+        # but implicitly add 1 to kraskov def
+        # because center point should be included
         n_points = len(tree.query_ball_point(points[i], dist - EPS,
                        p=float('inf')))
         avg += digamma(n_points) / n_samples

--- a/mdentropy/utils.py
+++ b/mdentropy/utils.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import time
 
-from numpy import dtype, finfo, nan_to_num, random, unique, void
+from numpy import dtype, finfo, float32, nan_to_num, random, unique, void
 
 from scipy.spatial import cKDTree
 from scipy.special import digamma
@@ -10,7 +10,7 @@ from scipy.special import digamma
 
 __all__ = ['floor_threshold', 'shuffle', 'Timing', 'unique_row_count',
            'avgdigamma']
-EPS = finfo(float).eps
+EPS = finfo(float32).eps
 
 
 class Timing(object):

--- a/mdentropy/utils.py
+++ b/mdentropy/utils.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import time
 
-from numpy import dtype, random, unique, void
+from numpy import dtype, nan_to_num, random, unique, void
 
 
 __all__ = ['floor_threshold', 'shuffle', 'Timing', 'unique_row_count']
@@ -75,6 +75,6 @@ def floor_threshold(arr, threshold=0.):
     new_arr : numpy.ndarray
         thresholded array
     """
-    new_arr = arr.copy()
+    new_arr = nan_to_num(arr.copy())
     new_arr[arr < threshold] = threshold
     return new_arr

--- a/scripts/dmutinf
+++ b/scripts/dmutinf
@@ -6,13 +6,15 @@ import mdtraj as md
 import pandas as pd
 from glob import glob
 from itertools import chain
+from numpy import pi
 
 from mdentropy.metrics import DihedralMutualInformation
 
 
 def run(traj, nbins, iter, N, types, method):
     mi = DihedralMutualInformation(n_bins=nbins, types=types,
-                                   method=method, threads=N)
+                                   method=method, threads=N,
+                                   rng=[-pi, pi])
 
     M = mi.partial_transform(traj, shuffle=iter, verbose=True)
 

--- a/scripts/dmutinf
+++ b/scripts/dmutinf
@@ -32,7 +32,7 @@ def parse_cmdln():
     parser.add_argument('-t', '--topology', dest='top',
                         help='File containing topology.', default=None)
     parser.add_argument('-b', '--n-bins', dest='nbins',
-                        help='Number of bins', default=3, type=int)
+                        help='Number of bins', default=None, type=int)
     parser.add_argument('-n', '--n-threads', dest='N',
                         help='Number of threads to be used.',
                         default=None, type=int)

--- a/scripts/dmutinf
+++ b/scripts/dmutinf
@@ -6,7 +6,6 @@ import mdtraj as md
 import pandas as pd
 from glob import glob
 from itertools import chain
-from numpy import pi
 
 from mdentropy.metrics import DihedralMutualInformation
 
@@ -14,7 +13,7 @@ from mdentropy.metrics import DihedralMutualInformation
 def run(traj, nbins, iter, N, types, method):
     mi = DihedralMutualInformation(n_bins=nbins, types=types,
                                    method=method, threads=N,
-                                   rng=[-pi, pi], normed=False)
+                                   normed=True)
 
     M = mi.partial_transform(traj, shuffle=iter, verbose=True)
 
@@ -45,7 +44,7 @@ def parse_cmdln():
                         help='Entropy estimate method.',
                         choices=['chaowangjost', 'grassberger', 'kde',
                                  'knn', 'naive'],
-                        default='grassberger')
+                        default='knn')
     parser.add_argument('-d', '--dihedrals', dest='dihedrals',
                         help='Dihedral angles to analyze.',
                         nargs='+',

--- a/scripts/dmutinf
+++ b/scripts/dmutinf
@@ -44,7 +44,7 @@ def parse_cmdln():
     parser.add_argument('-m', '--method', dest='method',
                         help='Entropy estimate method.',
                         choices=['chaowangjost', 'grassberger', 'kde',
-                                 'naive'],
+                                 'knn', 'naive'],
                         default='grassberger')
     parser.add_argument('-d', '--dihedrals', dest='dihedrals',
                         help='Dihedral angles to analyze.',

--- a/scripts/dmutinf
+++ b/scripts/dmutinf
@@ -14,7 +14,7 @@ from mdentropy.metrics import DihedralMutualInformation
 def run(traj, nbins, iter, N, types, method):
     mi = DihedralMutualInformation(n_bins=nbins, types=types,
                                    method=method, threads=N,
-                                   rng=[-pi, pi])
+                                   rng=[-pi, pi], normed=False)
 
     M = mi.partial_transform(traj, shuffle=iter, verbose=True)
 

--- a/scripts/dmutinf
+++ b/scripts/dmutinf
@@ -32,7 +32,7 @@ def parse_cmdln():
     parser.add_argument('-t', '--topology', dest='top',
                         help='File containing topology.', default=None)
     parser.add_argument('-b', '--n-bins', dest='nbins',
-                        help='Number of bins', default=24, type=int)
+                        help='Number of bins', default=3, type=int)
     parser.add_argument('-n', '--n-threads', dest='N',
                         help='Number of threads to be used.',
                         default=None, type=int)

--- a/scripts/dtent
+++ b/scripts/dtent
@@ -39,7 +39,7 @@ def parse_cmdln():
                         dest='top', help='File containing topology.',
                         default=None)
     parser.add_argument('-b', '--n-bins', dest='nbins',
-                        help='Number of bins', default=3, type=int)
+                        help='Number of bins', default=None, type=int)
     parser.add_argument('-n', '--n-threads', dest='N',
                         help='Number of threads', default=None, type=int)
     parser.add_argument('-o', '--output', dest='out',

--- a/scripts/dtent
+++ b/scripts/dtent
@@ -14,7 +14,7 @@ from mdentropy.metrics import DihedralTransferEntropy
 def run(past, current, nbins, iter, N, types, method):
     tent = DihedralTransferEntropy(n_bins=nbins, types=types,
                                    method=method, threads=N,
-                                   rng=[-pi, pi])
+                                   rng=[-pi, pi], normed=False)
 
     T = tent.partial_transform((past, current), shuffle=iter, verbose=True)
 

--- a/scripts/dtent
+++ b/scripts/dtent
@@ -6,7 +6,6 @@ import mdtraj as md
 import pandas as pd
 from glob import glob
 from itertools import chain
-from numpy import pi
 
 from mdentropy.metrics import DihedralTransferEntropy
 
@@ -14,7 +13,7 @@ from mdentropy.metrics import DihedralTransferEntropy
 def run(past, current, nbins, iter, N, types, method):
     tent = DihedralTransferEntropy(n_bins=nbins, types=types,
                                    method=method, threads=N,
-                                   rng=[-pi, pi], normed=False)
+                                   normed=True)
 
     T = tent.partial_transform((past, current), shuffle=iter, verbose=True)
 
@@ -49,7 +48,7 @@ def parse_cmdln():
                         help='Entropy estimate method.',
                         choices=['chaowangjost', 'grassberger', 'kde',
                                  'knn', 'naive'],
-                        default='grassberger')
+                        default='knn')
     parser.add_argument('-d', '--dihedrals', dest='dihedrals',
                         help='Dihedral angles to analyze.',
                         nargs='+',

--- a/scripts/dtent
+++ b/scripts/dtent
@@ -6,13 +6,15 @@ import mdtraj as md
 import pandas as pd
 from glob import glob
 from itertools import chain
+from numpy import pi
 
 from mdentropy.metrics import DihedralTransferEntropy
 
 
 def run(past, current, nbins, iter, N, types, method):
     tent = DihedralTransferEntropy(n_bins=nbins, types=types,
-                                   method=method, threads=N)
+                                   method=method, threads=N,
+                                   rng=[-pi, pi])
 
     T = tent.partial_transform((past, current), shuffle=iter, verbose=True)
 

--- a/scripts/dtent
+++ b/scripts/dtent
@@ -48,7 +48,7 @@ def parse_cmdln():
     parser.add_argument('-m', '--method', dest='method',
                         help='Entropy estimate method.',
                         choices=['chaowangjost', 'grassberger', 'kde',
-                                 'naive'],
+                                 'knn', 'naive'],
                         default='grassberger')
     parser.add_argument('-d', '--dihedrals', dest='dihedrals',
                         help='Dihedral angles to analyze.',

--- a/scripts/dtent
+++ b/scripts/dtent
@@ -39,7 +39,7 @@ def parse_cmdln():
                         dest='top', help='File containing topology.',
                         default=None)
     parser.add_argument('-b', '--n-bins', dest='nbins',
-                        help='Number of bins', default=24, type=int)
+                        help='Number of bins', default=3, type=int)
     parser.add_argument('-n', '--n-threads', dest='N',
                         help='Number of threads', default=None, type=int)
     parser.add_argument('-o', '--output', dest='out',


### PR DESCRIPTION
Implemented k-nearest neighbor estimators (as seen in [gregversteeg/NPEET](https://github.com/gregversteeg/NPEET)). Unlike the naive estimators, `knn` yields consistent results with appropriate choice of `k` and is much faster than `kde`.

Also added code to enable `knn` to be the default choice.