### PR TITLE
TEnt of discrete variable timeseries. Added example.

### DIFF
--- a/mdentropy/core/entropy.py
+++ b/mdentropy/core/entropy.py
@@ -4,9 +4,9 @@ from itertools import chain
 
 from numpy import ndarray
 from numpy import sum as npsum
-from numpy import (atleast_2d, arange, bincount, diff, finfo, float32,
+from numpy import (atleast_2d, arange, array, bincount, diff, finfo, float32,
                    hsplit, linspace, log, log2, meshgrid, nan_to_num, nansum,
-                   product, random, ravel, vstack, exp)
+                   product, random, ravel, vstack, exp, bincount)
 
 from scipy.spatial import cKDTree
 from scipy.stats import entropy as naive
@@ -57,7 +57,11 @@ def entropy(n_bins, rng, method, *args):
     if method == 'kde':
         return kde_entropy(rng, *args, grid_size=n_bins or 20)
 
-    counts = symbolic(n_bins, rng, *args)
+    if n_bins is not None:
+        counts = symbolic(n_bins, rng, *args)
+    else:
+        minlength = max([len(bincount(arg)) for arg in args])
+        counts = array([bincount(arg, minlength=minlength) for arg in args])
 
     if method == 'chaowangjost':
         return chaowangjost(counts)
@@ -67,7 +71,7 @@ def entropy(n_bins, rng, method, *args):
     return naive(counts)
 
 
-def centropy(n_bins, x, y, rng=None, method='grassberger'):
+def centropy(n_bins, x, y, rng=None, method='knn'):
     """Condtional entropy calculation
 
     Parameters

--- a/mdentropy/core/information.py
+++ b/mdentropy/core/information.py
@@ -1,7 +1,8 @@
 from .entropy import entropy, centropy
 from ..utils import avgdigamma
 
-from numpy import (atleast_2d, diff, finfo, float32, log, nan_to_num, random,
+from numpy import (atleast_2d, diff, finfo, float32, integer, issubdtype,
+                 log, nan_to_num, random,
                    sqrt, hstack)
 
 from scipy.spatial import cKDTree
@@ -11,7 +12,7 @@ __all__ = ['mutinf', 'nmutinf', 'cmutinf', 'ncmutinf']
 EPS = finfo(float32).eps
 
 
-def mutinf(n_bins, x, y, rng=None, method='grassberger'):
+def mutinf(n_bins, x, y, rng=None, method='knn'):
     """Mutual information calculation
 
     Parameters
@@ -73,7 +74,7 @@ def knn_mutinf(x, y, k=None, boxsize=None):
     return (-a - b + c + d) / log(2)
 
 
-def nmutinf(n_bins, x, y, rng=None, method='grassberger'):
+def nmutinf(n_bins, x, y, rng=None, method='knn'):
     """Normalized mutual information calculation
 
     Parameters
@@ -97,7 +98,7 @@ def nmutinf(n_bins, x, y, rng=None, method='grassberger'):
                       entropy(n_bins, [rng], method, y)))
 
 
-def cmutinf(n_bins, x, y, z, rng=None, method='grassberger'):
+def cmutinf(n_bins, x, y, z, rng=None, method='knn'):
     """Conditional mutual information calculation
 
     Parameters
@@ -164,13 +165,18 @@ def knn_cmutinf(x, y, z, k=None, boxsize=None):
     return (-a - b + c + d) / log(2)
 
 
-def ncmutinf(n_bins, x, y, z, rng=None, method='grassberger'):
+def ncmutinf(n_bins, x, y, z, rng=None, method='knn'):
     """Normalized conditional mutual information calculation
 
     Parameters
     ----------
     n_bins : int
         Number of bins.
+
+        If None, assumes data is pre-binned or a timeseries
+        of discrete variables. In this case, x, y, and z
+        must all be of some integer type: "int", "uint8", etc.
+
     x : array_like, shape = (n_samples, n_dim)
         Conditioned variable
     y : array_like, shape = (n_samples, n_dim)
@@ -185,6 +191,11 @@ def ncmutinf(n_bins, x, y, z, rng=None, method='grassberger'):
     -------
     ncmi : float
     """
+
+    if n_bins is None:
+        assert(issubdtype(x.dtype, integer))
+        method = 'grassberger'
+        rng = None
 
     return (cmutinf(n_bins, x, y, z, rng=rng, method=method) /
             centropy(n_bins, x, z, rng=rng, method=method))


### PR DESCRIPTION
In this PR, we add the ability to directly compute transfer entropy with timeseries containing discrete random variables or, equivalently, continuous data that has been pre-binned. This has been accomplished by adding a ```n_bins=None``` to ```entropy()```. If ```n_bins=None```, ```entropy()``` will compute ```counts``` with ```numpy.bincount()```, which will directly count the frequency of each discrete label for each variable. This functionality is added at a higher level to ```ncmutinf()```, which gives the option of passing ```int``` timeseries and ```n_bins=None```, which will then compute Transfer Entropy in the way described above. 

In addition, an example has been added in an ```examples``` folder demonstrating a usage of the above and generally how to flexibly use the ```MDEntropy``` API.